### PR TITLE
Fix test case to work in other timezones than UTC

### DIFF
--- a/spec/outputs/mqtt_spec.rb
+++ b/spec/outputs/mqtt_spec.rb
@@ -3,11 +3,15 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/mqtt"
 require "logstash/codecs/json"
 require "logstash/event"
+require "time"
 
 describe LogStash::Outputs::MQTT do
   # Define a sample event and its JSON encoded form
-  let(:sample_event) { LogStash::Event.new("message" => "test message", "@timestamp" => "2016-01-01") }
-  encoded_event = "{\"message\":\"test message\",\"@timestamp\":\"2016-01-01T00:00:00.000Z\",\"@version\":\"1\"}"
+  datestring = "2016-01-01"
+  tstamp = Time.parse(datestring)
+  tstamp_utc = tstamp.utc.iso8601(3)
+  let(:sample_event) { LogStash::Event.new("message" => "test message", "@timestamp" => datestring) }
+  encoded_event = "{\"message\":\"test message\",\"@timestamp\":\"" + tstamp_utc + "\",\"@version\":\"1\"}"
 
   settings = {
     "host" => "test.mosquitto.org",


### PR DESCRIPTION
Since logstash converts the given timestamp to UTC, this part
in the "expected message" depends on the timezone where the test
case is executed. With calculating this, the code is now timezone
independent.
