### PR TITLE
Reuse mqtt connection when possible

### DIFF
--- a/logstash-output-mqtt.gemspec
+++ b/logstash-output-mqtt.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "mqtt"
 
   # 1.3.5 version has some problems, stick to 1.3.4 by now
-  s.add_development_dependency "logstash-devutils", "< 1.3.5"
+  s.add_development_dependency "logstash-devutils", "< 1.3.6"
 end

--- a/spec/outputs/mqtt_spec.rb
+++ b/spec/outputs/mqtt_spec.rb
@@ -4,6 +4,7 @@ require "logstash/outputs/mqtt"
 require "logstash/codecs/json"
 require "logstash/event"
 require "time"
+require "json"
 
 describe LogStash::Outputs::MQTT do
   # Define a sample event and its JSON encoded form
@@ -11,48 +12,37 @@ describe LogStash::Outputs::MQTT do
   tstamp = Time.parse(datestring)
   tstamp_utc = tstamp.utc.iso8601(3)
   let(:sample_event) { LogStash::Event.new("message" => "test message", "@timestamp" => datestring) }
-  encoded_event = "{\"@timestamp\":\"" + tstamp_utc + "\",\"@version\":\"1\",\"message\":\"test message\"}"
+  encoded_event = "{\"message\":\"test message\",\"@version\":\"1\",\"@timestamp\":\"" + tstamp_utc + "\"}"
 
   settings = {
     "host" => "test.mosquitto.org",
     "topic" => "hello"
   }
   let(:output) { LogStash::Outputs::MQTT.new(settings) }
-  let(:stub_client) { Object.new }
+  let(:stub_client) { instance_double(MQTT::Client) }
 
   before do
     output.register
   end
 
   describe "receive message" do
-
     it "connects and publishes with correct arguments" do
-
       expect(MQTT::Client).to receive(:connect).with(
         :host => "test.mosquitto.org",
         :port => 8883
-      ) do |*args, &block|
-        block.call(stub_client)
-      end
-
+      ).and_return(stub_client)
       expect(stub_client).to receive(:publish).with("hello", encoded_event, false, 0)
-
       output.receive(sample_event)
     end
   end
 
   describe "multi_receive" do
     it "connects once and publishes all messages" do
-
       expect(MQTT::Client).to receive(:connect).once.with(
         :host => "test.mosquitto.org",
         :port => 8883
-      ) do |*args, &block|
-        block.call(stub_client)
-      end
-
+      ).and_return(stub_client)
       expect(stub_client).to receive(:publish).exactly(3).times.with("hello", encoded_event, false, 0)
-
       three_events = [sample_event, sample_event, sample_event]
       output.multi_receive(three_events)
     end
@@ -65,14 +55,14 @@ describe "Test subtopic:" do
   tstamp = Time.parse(datestring)
   tstamp_utc = tstamp.utc.iso8601(3)
   let(:sample_event) { LogStash::Event.new("message" => "test message", "@timestamp" => datestring, "subtopic" => "mysubtopic") }
-  encoded_event = "{\"@timestamp\":\"" + tstamp_utc + "\",\"@version\":\"1\",\"message\":\"test message\",\"subtopic\":\"mysubtopic\"}"
+  encoded_event = "{\"@version\":\"1\",\"@timestamp\":\"" + tstamp_utc + "\",\"message\":\"test message\",\"subtopic\":\"mysubtopic\"}"
 
   settings = {
     "host" => "test.mosquitto.org",
     "topic" => "hello/%{subtopic}"
   }
   let(:output) { LogStash::Outputs::MQTT.new(settings) }
-  let(:stub_client) { Object.new }
+  let(:stub_client) { instance_double(MQTT::Client) }
 
   before do
     output.register
@@ -80,16 +70,11 @@ describe "Test subtopic:" do
 
   describe "receive message on a subtopic based on a field of an event" do
     it "connects and publishes" do
-
       expect(MQTT::Client).to receive(:connect).with(
         :host => "test.mosquitto.org",
         :port => 8883
-      ) do |*args, &block|
-        block.call(stub_client)
-      end
-
+      ).and_return(stub_client)
       expect(stub_client).to receive(:publish).with("hello/mysubtopic", encoded_event, false, 0)
-
       output.receive(sample_event)
     end
   end


### PR DESCRIPTION
This solves issues with log running pipelines into AWS IoT,